### PR TITLE
Translate 'invalid-aria-prop' warning page

### DIFF
--- a/content/warnings/invalid-aria-prop.md
+++ b/content/warnings/invalid-aria-prop.md
@@ -8,4 +8,4 @@ Ostrzeżenie `invalid-aria-prop` pojawi się, gdy spróbujesz wyrenderować elem
 
 1. Jeśli wydaje ci się, że używasz poprawnej właściwości, sprawdź, czy nie ma w niej literówki. Najczęściej błędy zdarzają się w nazwach typu `aria-labelledby` czy `aria-activedescendant`.
 
-2. Być może React jeszcze nie rozpoznaje użytej przez ciebie właściwości. Zostanie to najprawdopodobniej naprawione w przyszłej wersji. Obecnie jednak React usuwa wszystkie nieznane właściwości, więc użycie ich w aplikacji nie powinno spowodować ich wyrenderowania.
+2. Być może React jeszcze nie rozpoznaje użytej przez ciebie właściwości. Zostanie to najprawdopodobniej naprawione w przyszłej wersji. Obecnie jednak React usuwa wszystkie nieznane właściwości, więc użycie ich w aplikacji nie spowoduje ich wyrenderowania.

--- a/content/warnings/invalid-aria-prop.md
+++ b/content/warnings/invalid-aria-prop.md
@@ -4,8 +4,8 @@ layout: single
 permalink: warnings/invalid-aria-prop.html
 ---
 
-The invalid-aria-prop warning will fire if you attempt to render a DOM element with an aria-* prop that does not exist in the Web Accessibility Initiative (WAI) Accessible Rich Internet Application (ARIA) [specification](https://www.w3.org/TR/wai-aria-1.1/#states_and_properties).
+Ostrzeżenie `invalid-aria-prop` pojawi się, gdy spróbujesz wyrenderować element DOM z właściwością `aria-*`, która nie istnieje w [specyfikacji](https://www.w3.org/TR/wai-aria-1.1/#states_and_properties) Accessible Rich Internet Application (ARIA) stworzonej przez Web Accessibility Initiative (WAI).
 
-1. If you feel that you are using a valid prop, check the spelling carefully. `aria-labelledby` and `aria-activedescendant` are often misspelled.
+1. Jeśli wydaje ci się, że używasz poprawnej właściwości, sprawdź, czy nie ma w niej literówki. Najczęściej błędy zdarzają się w nazwach typu `aria-labelledby` czy `aria-activedescendant`.
 
-2. React does not yet recognize the attribute you specified. This will likely be fixed in a future version of React. However, React currently strips all unknown attributes, so specifying them in your React app will not cause them to be rendered
+2. Być może React jeszcze nie rozpoznaje użytej przez ciebie właściwości. Zostanie to najprawdopodobniej naprawione w przyszłej wersji. Obecnie jednak React usuwa wszystkie nieznane właściwości, więc użycie ich w aplikacji nie powinno spowodować ich wyrenderowania.


### PR DESCRIPTION
The translation guide says that we shouldn't translate the warning messages, because people often search for them in Google, and we want to keep the good SEO.