### PR TITLE
Fix typo in React.lazy & Suspense note

### DIFF
--- a/content/docs/code-splitting.md
+++ b/content/docs/code-splitting.md
@@ -115,7 +115,7 @@ składnię dynamicznego importu, ale jej nie przekształca w żaden sposób. W t
 
 > Uwaga:
 >
-> `React.lazy` i Suspense są jest jeszcze dostępne dla renderowania po stronie serwera.
+> `React.lazy` i `Suspense` nie są jeszcze dostępne dla renderowania po stronie serwera.
 > Jeśli chcesz dzielić kod dla aplikacji renderowanej na serwerze, sugerujemy skorzystać 
 > z pakietu [Loadable Components](https://github.com/smooth-code/loadable-components).  
 > Ma on przystępną [instrukcję dzielenia pakietów przy renderowaniu po stronie serwera](https://github.com/smooth-code/loadable-components/blob/master/packages/server/README.md).


### PR DESCRIPTION
Looked like typo so I fixed it :)