### PR TITLE
Fix the list about whether to use state

### DIFF
--- a/content/docs/thinking-in-react.md
+++ b/content/docs/thinking-in-react.md
@@ -94,7 +94,7 @@ Przyjrzyjmy się wszystkim rodzajom informacji w naszej przykładowej aplikacji.
 Aby zdecydować, która z powyższych informacji zalicza się do stanu, w przypadku każdej z nich musimy zadać sobie trzy pytania:
 
   1. Czy informacja ta jest przekazywana za pomocą atrybutu? Jeśli tak, to prawdopodobnie nie wchodzi w skład stanu.
-  2. Czy informacja ta może z czasem ulec zmianom? Jeśli tak, to prawdopodobnie nie wchodzi w skład stanu.
+  2. Czy informacja ta pozostanie niezmienna na przestrzeni czasu? Jeśli tak, to prawdopodobnie nie wchodzi w skład stanu.
   3. Czy informację tę można wygenerować na podstawie innego stanu lub atrybutu w danym komponencie. Jeśli tak, to nie należy zaliczyć jej do stanu.
 
 Początkowa lista produktów jest przekazywana jako atrybut, zatem nie jest stanem. Wyszukiwana fraza i wartość odznaczonego pola wydają się wchodzić w skład stanu, ponieważ mogą ulegać zmianom i nie da się ich w żaden sposób wygenerować. Jeśli chodzi o listę produktów spełniających kryteria wyszukiwania, to nie jest ona stanem, ponieważ może być wygenerowana na podstawie wyszukiwanej frazy i wartości odznaczonego pola.


### PR DESCRIPTION
W punkcie drugim na liście dot. podejmowania decyzji o wykorzystaniu stanu w komponencie pojawił się błąd zaprzeczający idei stanu.
Możemy przeczytać, że informacja NIE wchodzi w skład stanu, jeżeli może ulec zmianom:

"Czy informacja ta może z czasem ulec zmianom? Jeśli tak, to prawdopodobnie nie wchodzi w skład stanu."

Dalej w tekście piszemy, że:
"Wyszukiwana fraza i wartość odznaczonego pola WYDAJĄ SIĘ wchodzić w skład stanu, ponieważ mogą ulegać zmianom"

Dla porównania ten punkt w wersji angielskiej:
"Does it remain unchanged over time? If so, it probably isn’t state."



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
