### PR TITLE
Fix typo in error-boundaries.md

### DIFF
--- a/content/docs/error-boundaries.md
+++ b/content/docs/error-boundaries.md
@@ -69,7 +69,7 @@ Należy pamiętać, że **granice błędów wyłapują błędy w komponentach po
 
 ## Gdzie umiejscowić granice błędów {#where-to-place-error-boundaries}
 
-Poziom granularności granic błędów zależy wyłącznie od ciebie. Możesz opakować tylko główny komponent aplikacji i wyświetlać tekst "Coś poszło nie tak", jak to zwykle robi się we frameworkach serwerowycha. Możesz też otoczyć każdy z widgetów aplikacji osobną granicą błędów, aby błędy w ich wnętrzu nie zabijały całej aplikacji.
+Poziom granularności granic błędów zależy wyłącznie od ciebie. Możesz opakować tylko główny komponent aplikacji i wyświetlać tekst "Coś poszło nie tak", jak to zwykle robi się we frameworkach serwerowych. Możesz też otoczyć każdy z widgetów aplikacji osobną granicą błędów, aby błędy w ich wnętrzu nie zabijały całej aplikacji.
 
 ## Nowe zachowanie nieobsłużonych błędów {#new-behavior-for-uncaught-errors}
 


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
This PR is fixing a typo inside `error-boundaries.md`
