### PR TITLE
Fix typo in JSX markup challenge solution

### DIFF
--- a/src/content/learn/writing-markup-with-jsx.md
+++ b/src/content/learn/writing-markup-with-jsx.md
@@ -323,7 +323,7 @@ export default function Bio() {
       <p className="summary">
         Wrzucam na nią swoje przemyślenia.
         <br /><br />
-        <b>I <i>zdjęcia</i></b> of naukowców!
+        <b>I <i>zdjęcia</i></b> naukowców!
       </p>
     </div>
   );


### PR DESCRIPTION
Remaining "of" was an obvious remnant from the original (English) version

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
